### PR TITLE
Enable scrolling with up/down keys

### DIFF
--- a/src/cairo.zig
+++ b/src/cairo.zig
@@ -63,6 +63,8 @@ pub const CairoBackend = struct {
 
     pub const BackspaceKey = c.GLFW_KEY_BACKSPACE;
     pub const EnterKey = c.GLFW_KEY_ENTER;
+    pub const UpKey = c.GLFW_KEY_UP;
+    pub const DownKey = c.GLFW_KEY_DOWN;
 
     pub const MouseButton = enum(c_int) {
         Left = c.GLFW_MOUSE_BUTTON_LEFT,

--- a/src/main.zig
+++ b/src/main.zig
@@ -196,6 +196,12 @@ fn keyPressed(backend: *GraphicsBackend, key: u32, mods: u32) void {
             openPage(&renderCtx, url) catch unreachable;
             backend.frame_requested = true;
         }
+    } else {
+        if (key == GraphicsBackend.UpKey) {
+            RenderContext.scrollPage(backend, true);
+        } else if (key == GraphicsBackend.DownKey) {
+            RenderContext.scrollPage(backend, false);
+        }
     }
 }
 

--- a/zervo/renderer.zig
+++ b/zervo/renderer.zig
@@ -139,6 +139,17 @@ pub fn RenderContext(comptime T: type) type {
             backend.frame_requested = true;
         }
 
+        pub fn scrollPage(backend: *T, up: bool) void {
+            const self = @intToPtr(*Self, backend.userData);
+            if (up) {
+                self.offsetYTarget += 25.0;
+            } else {
+                self.offsetYTarget -= 25.0;
+            }
+            if (self.offsetYTarget > 0) self.offsetYTarget = 0;
+            backend.frame_requested = true;
+        }
+
         pub fn mouseButtonCallback(backend: *T, button: T.MouseButton, pressed: bool) void {
             const self = @intToPtr(*Self, backend.userData);
             const event = Event {


### PR DESCRIPTION
Could possibly be handled better with an enum if one wanted left/right scrolling with keys, but for my use this is good enough. Just scrolls +/- 25.0 with the up/down arrow keys because I don't usually have a mouse attached to my laptop.